### PR TITLE
AUT-308 enable shadow copy for specflow tests

### DIFF
--- a/Specflow.fsx
+++ b/Specflow.fsx
@@ -42,8 +42,8 @@ let run (config : Map<string, string>) _ =
                     OutputFile = specFlowResultXmlFile
                     IncludeCategory = testCategories 
                     ErrorLevel = DontFailBuild
-                    DisableShadowCopy = true
+                    DisableShadowCopy = false
                     ShowLabels = true
-                    TimeOut = TimeSpan(1,0,0)
+                    TimeOut = TimeSpan.FromHours 1.
                     })       
         generateSpecFlowReport config


### PR DESCRIPTION
enable shadow copy for specflow tests - attempt to avoid file locking when it is disabled
