### PR TITLE
remove protractor target and add dependency to run Grunt after grunt install

### DIFF
--- a/Core.fsx
+++ b/Core.fsx
@@ -52,7 +52,6 @@ Target "Versioning:UpdateDeployNuspec" <| Versioning.updateDeploy config
 Target "Grunt:Install"                 <| Grunt.install config
 Target "Grunt:Run"                     <| Grunt.run config
 Target "Grunt:Karma"                   <| Grunt.karma config
-Target "Grunt:Protractor"              <| Grunt.protractor config
 Target "Test:Run"                      <| Test.run config
 Target "SpecFlow:Run"                  <| Specflow.run config
 
@@ -65,6 +64,10 @@ Target "SpecFlow:Run"                  <| Specflow.run config
     ==> "SpecFlow:Run"
     ==> "Test:Run"
     =?> ("Packaging:Push", not isLocalBuild)
+    ==> "Default"
+
+"Grunt:Install"
+    ==> "Grunt:Run"
     ==> "Default"
 
 RunParameterTargetOrDefault "target" "Default"

--- a/Grunt.fsx
+++ b/Grunt.fsx
@@ -56,16 +56,3 @@ let karma (config : Map<string, string>) _ =
     if result <> 0 then failwith (sprintf "Karma reporting failure - at least one test has failed: %d" result)
     
     ()
-
-let protractor (config : Map<string, string>) _ =
-
-    let args = "\"" + grunt + "\" protractor"
-
-    let result =
-        ExecProcess (fun info ->
-            info.FileName <- node
-            info.WorkingDirectory <- ".\\build"
-            info.Arguments <- args) (TimeSpan.FromMinutes 20.)
-
-    if result <> 0 then failwith (sprintf "Protractor reporting failure - at least one test has failed: %d" result)
-    ()


### PR DESCRIPTION
Enables protractor e2e tests to be run on team city via Grunt:run
