### PR TITLE
Ensure that specflow test run does not depend on packaging 

### DIFF
--- a/Core.fsx
+++ b/Core.fsx
@@ -63,8 +63,8 @@ Target "Docker:Package"                <| Docker.dockerize config
 "Solution:Clean"
     ==> "Versioning:Update"
     ==> "Solution:Build"
-    ==> "Packaging:Package"
     ==> "SpecFlow:Run"
+    ==> "Packaging:Package"
     ==> "Test:Run"
     =?> ("Packaging:Push", not isLocalBuild)
     ==> "Default"


### PR DESCRIPTION
Ensure that specflow test run does not depend on packaging 
swap build order.